### PR TITLE
Fix remaining invalid branch name syntax

### DIFF
--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -60,7 +60,7 @@ github-reset()
 {
     git reset --hard
     git checkout master
-    git branch -D ${source}:${branch}
+    git branch -D ${source}-${branch}
 }
 
 [ $# = 3 ] || usage


### PR DESCRIPTION
The reset method still had the wrong syntax for branch name.
Fixes #2.
