### PR TITLE
Convert git-ghpr to use the GitHub JSON API

### DIFF
--- a/git-ghpr/README
+++ b/git-ghpr/README
@@ -3,5 +3,7 @@
 Crude helper tool for merging pull requests on github, when the
 workflow requires that all commits are gpg signed.
 
+Requires the curl and jq utilities.
+
 Copy bin/git-ghpr to somewhere in $PATH, to make the `git ghpr`
 subcommand available.

--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -93,11 +93,15 @@ EOF
     git log --pretty='* %h %s' $merge_base..$merge_head >>$msgfile
 }
 
+github-commit()
+{
+    git commit -S -e -F $msgfile || return
+}
+
 parse-command-line()
 {
     [ $# = 3 ] || usage
 
-    topdir=$(git rev-parse --show-toplevel)
     upstream_url=$(git remote get-url upstream)
     project=$(basename $upstream_url .git)
     source=$(<<< "$2" cut -d: -f1 --only-delimited)
@@ -105,14 +109,6 @@ parse-command-line()
     [ -z "$source" -o -z "$branch" ] && usage
     source_url=https://github.com/$source/$project
     preq=$3
-    msgfile="$topdir/.git/PULL_REQUEST_EDITMSG"
-}
-
-github-commit()
-{
-    parse-command-line "$@"
-
-    git commit -S -e -F $msgfile || return
 }
 
 github-push()
@@ -132,6 +128,9 @@ github-reset()
     git checkout master
     git branch -D ${source}-${branch}
 }
+
+topdir=$(git rev-parse --show-toplevel)
+msgfile="$topdir/.git/PULL_REQUEST_EDITMSG"
 
 case "$1" in
     list|show|pull|commit|push|reset)

--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -3,7 +3,9 @@
 usage()
 {
     cat <<EOF >&2
-usage: $(basename $0) <command> <github-fork>:<branch> <pullrequest#>
+usage: $(basename $0) list
+       $(basename $0) <command> (<pullrequest#>)
+       $(basename $0) <command> <github-fork>:<branch> <pullrequest#>
 
 GitHub pull request helper.
 
@@ -14,9 +16,9 @@ Commands:
 
 list:   List open pull requests in the upstream repository.
 
-show <pullrequest#>: Show detailed information about a pull request.
+show <pr#>: Show detailed information about a pull request.
 
-pull:   Pulls forked branch into local branch of upstream/master, and
+pull <pr#>: Pulls forked branch into local branch of upstream/master, and
         leaves it in a non-committed state for inspection and testing.
 
 commit: Commits merge with a GPG signed constructed commit message.
@@ -65,6 +67,32 @@ Branch: \(.head.ref)
 \(.body)"'
 }
 
+github-pull()
+{
+    [ $# = 2 ] || usage
+
+    local org repo preq json source branch source_url merge_base merge_head
+    org=$(git remote get-url upstream | cut -d: -f2 | cut -d/ -f1)
+    repo=$(basename $(git remote get-url upstream | cut -d: -f2 | cut -d/ -f2) .git)
+    preq=$2
+    json=$(curl --silent https://api.github.com/repos/$org/$repo/pulls/$preq)
+    source=$(<<< $json jq -r '@text "\(.head.repo.owner.login)"')
+    branch=$(<<< $json jq -r '@text "\(.head.ref)"')
+    source_url=https://github.com/$(<<< $json jq -r '@text "\(.head.repo.full_name)"')
+
+    git checkout -b ${source}-${branch} upstream/master || return
+    git pull --ff-only || return
+    git pull --no-ff --verify-signatures --no-commit "$source_url" "$branch" || return
+    merge_base=$(cat "$topdir/.git/ORIG_HEAD")
+    merge_head=$(cat "$topdir/.git/MERGE_HEAD")
+
+    cat <<EOF >$msgfile
+Merge pull request #$preq from $source/$branch
+
+EOF
+    git log --pretty='* %h %s' $merge_base..$merge_head >>$msgfile
+}
+
 parse-command-line()
 {
     [ $# = 3 ] || usage
@@ -78,25 +106,6 @@ parse-command-line()
     source_url=https://github.com/$source/$project
     preq=$3
     msgfile="$topdir/.git/PULL_REQUEST_EDITMSG"
-}
-
-github-pull()
-{
-    parse-command-line "$@"
-
-    local merge_base merge_head
-
-    git checkout -b ${source}-${branch} upstream/master || return
-    git pull --ff-only || return
-    git pull --no-ff --verify-signatures --no-commit "$source_url" "$branch" || return
-    merge_base=$(cat "$topdir/.git/ORIG_HEAD")
-    merge_head=$(cat "$topdir/.git/MERGE_HEAD")
-
-    cat <<EOF >$msgfile
-Merge pull request #$preq from $source/$branch
-
-EOF
-    git log --pretty='* %h %s' $merge_base..$merge_head >>$msgfile
 }
 
 github-commit()

--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -80,7 +80,7 @@ github-pull()
 
     get-pr-from-api $2
 
-    local preq merge_base merge_head
+    local merge_base merge_head
 
     git checkout -b ${source}-${branch} upstream/master || return
     git pull --ff-only || return
@@ -89,7 +89,7 @@ github-pull()
     merge_head=$(cat "$topdir/.git/MERGE_HEAD")
 
     cat <<EOF >$msgfile
-Merge pull request #$preq from $source/$branch
+Merge pull request #$2 from $source/$branch
 
 EOF
     git log --pretty='* %h %s' $merge_base..$merge_head >>$msgfile

--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -127,8 +127,8 @@ github-reset()
 topdir=$(git rev-parse --show-toplevel)
 msgfile="$topdir/.git/PULL_REQUEST_EDITMSG"
 
-org=$(git remote get-url upstream | cut -d: -f2 | cut -d/ -f1)
-repo=$(basename $(git remote get-url upstream | cut -d: -f2 | cut -d/ -f2) .git)
+org=$(git remote get-url upstream | sed -e 's/^.*@github.com[:/]//' | cut -d/ -f1)
+repo=$(basename $(git remote get-url upstream | sed -e 's/^.*@github.com[:/]//' | cut -d/ -f2) .git)
 
 case "$1" in
     list|show|pull|commit|push|reset)

--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -35,7 +35,8 @@ EOF
 
 get-pr-from-api()
 {
-    json=$(curl --silent https://api.github.com/repos/$org/$repo/pulls/$1)
+    json=$(curl --user-agent 'git-ghpr (https://github.com/saab-simc-admin/workflow-tools)' \
+                --silent https://api.github.com/repos/$org/$repo/pulls/$1)
     source=$(<<< $json jq -r '@text "\(.head.repo.owner.login)"')
     branch=$(<<< $json jq -r '@text "\(.head.ref)"')
     source_url=https://github.com/$(<<< $json jq -r '@text "\(.head.repo.full_name)"')
@@ -45,7 +46,8 @@ github-list()
 {
     [ $# = 1 ] || usage
 
-    curl --silent https://api.github.com/repos/$org/$repo/pulls | \
+    curl --user-agent 'git-ghpr (https://github.com/saab-simc-admin/workflow-tools)' \
+         --silent https://api.github.com/repos/$org/$repo/pulls | \
         jq -r \
            '.[] |
             @text "\(.number) (\(.head.label)): \(.title)"'

--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -4,8 +4,7 @@ usage()
 {
     cat <<EOF >&2
 usage: $(basename $0) list
-       $(basename $0) <command> (<pullrequest#>)
-       $(basename $0) <command> <github-fork>:<branch> <pullrequest#>
+       $(basename $0) <command> <pullrequest#>
 
 GitHub pull request helper.
 
@@ -14,30 +13,38 @@ repository
 
 Commands:
 
-list:   List open pull requests in the upstream repository.
+list:           List open pull requests in the upstream repository.
 
-show <pr#>: Show detailed information about a pull request.
+show <pr#>:     Show detailed information about a pull request.
 
-pull <pr#>: Pulls forked branch into local branch of upstream/master, and
-        leaves it in a non-committed state for inspection and testing.
+pull <pr#>:     Pulls forked branch into local branch of upstream/master,
+                and leaves it in a non-committed state for inspection
+                and testing.
 
-commit: Commits merge with a GPG signed constructed commit message.
+commit (<pr#>): Commits merge with a GPG signed constructed commit
+                message. Pull request number is allowed, but not used.
 
-push:   Pushes to "upstream master" and cleans up temporary branch.
+push <pr#>:     Pushes to "upstream master" and cleans up temporary
+                branch.
 
-reset:  Resets working copy to local master and deletes the temporary
-        pull request branch.
-
-WARNING: No github API validation of the PR is done.
+reset <pr#>:    Resets working copy to local master and deletes the
+                temporary pull request branch.
 EOF
     exit 1
 }
 
+get-pr-from-api()
+{
+    json=$(curl --silent https://api.github.com/repos/$org/$repo/pulls/$1)
+    source=$(<<< $json jq -r '@text "\(.head.repo.owner.login)"')
+    branch=$(<<< $json jq -r '@text "\(.head.ref)"')
+    source_url=https://github.com/$(<<< $json jq -r '@text "\(.head.repo.full_name)"')
+}
+
 github-list()
 {
-    local org repo
-    org=$(git remote get-url upstream | cut -d: -f2 | cut -d/ -f1)
-    repo=$(basename $(git remote get-url upstream | cut -d: -f2 | cut -d/ -f2) .git)
+    [ $# = 1 ] || usage
+
     curl --silent https://api.github.com/repos/$org/$repo/pulls | \
         jq -r \
            '.[] |
@@ -48,12 +55,10 @@ github-show()
 {
     [ $# = 2 ] || usage
 
-    local org repo num
-    org=$(git remote get-url upstream | cut -d: -f2 | cut -d/ -f1)
-    repo=$(basename $(git remote get-url upstream | cut -d: -f2 | cut -d/ -f2) .git)
-    curl --silent https://api.github.com/repos/$org/$repo/pulls/$2 | \
-        jq -r \
-           '@text
+    get-pr-from-api $2
+
+    <<< $json jq -r \
+        '@text
 "Pull request #\(.number): \(.title)
 URL: \(.html_url)
 Label: \(.head.label)
@@ -71,14 +76,9 @@ github-pull()
 {
     [ $# = 2 ] || usage
 
-    local org repo preq json source branch source_url merge_base merge_head
-    org=$(git remote get-url upstream | cut -d: -f2 | cut -d/ -f1)
-    repo=$(basename $(git remote get-url upstream | cut -d: -f2 | cut -d/ -f2) .git)
-    preq=$2
-    json=$(curl --silent https://api.github.com/repos/$org/$repo/pulls/$preq)
-    source=$(<<< $json jq -r '@text "\(.head.repo.owner.login)"')
-    branch=$(<<< $json jq -r '@text "\(.head.ref)"')
-    source_url=https://github.com/$(<<< $json jq -r '@text "\(.head.repo.full_name)"')
+    get-pr-from-api $2
+
+    local preq merge_base merge_head
 
     git checkout -b ${source}-${branch} upstream/master || return
     git pull --ff-only || return
@@ -95,25 +95,16 @@ EOF
 
 github-commit()
 {
+    [ $# = 1 -o $# = 2 ] || usage
+
     git commit -S -e -F $msgfile || return
-}
-
-parse-command-line()
-{
-    [ $# = 3 ] || usage
-
-    upstream_url=$(git remote get-url upstream)
-    project=$(basename $upstream_url .git)
-    source=$(<<< "$2" cut -d: -f1 --only-delimited)
-    branch=$(<<< "$2" cut -d: -f2 --only-delimited)
-    [ -z "$source" -o -z "$branch" ] && usage
-    source_url=https://github.com/$source/$project
-    preq=$3
 }
 
 github-push()
 {
-    parse-command-line "$@"
+    [ $# = 2 ] || usage
+
+    get-pr-from-api $2
 
     git push upstream HEAD:master && rm $msgfile
     git checkout master
@@ -122,7 +113,9 @@ github-push()
 
 github-reset()
 {
-    parse-command-line "$@"
+    [ $# = 2 ] || usage
+
+    get-pr-from-api $2
 
     git reset --hard
     git checkout master
@@ -131,6 +124,9 @@ github-reset()
 
 topdir=$(git rev-parse --show-toplevel)
 msgfile="$topdir/.git/PULL_REQUEST_EDITMSG"
+
+org=$(git remote get-url upstream | cut -d: -f2 | cut -d/ -f1)
+repo=$(basename $(git remote get-url upstream | cut -d: -f2 | cut -d/ -f2) .git)
 
 case "$1" in
     list|show|pull|commit|push|reset)

--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -27,8 +27,25 @@ EOF
     exit 1
 }
 
+parse-command-line()
+{
+    [ $# = 3 ] || usage
+
+    topdir=$(git rev-parse --show-toplevel)
+    upstream_url=$(git remote get-url upstream)
+    project=$(basename $upstream_url .git)
+    source=$(<<< "$2" cut -d: -f1 --only-delimited)
+    branch=$(<<< "$2" cut -d: -f2 --only-delimited)
+    [ -z "$source" -o -z "$branch" ] && usage
+    source_url=https://github.com/$source/$project
+    preq=$3
+    msgfile="$topdir/.git/PULL_REQUEST_EDITMSG"
+}
+
 github-pull()
 {
+    parse-command-line "$@"
+
     local merge_base merge_head
 
     git checkout -b ${source}-${branch} upstream/master || return
@@ -46,11 +63,15 @@ EOF
 
 github-commit()
 {
+    parse-command-line "$@"
+
     git commit -S -e -F $msgfile || return
 }
 
 github-push()
 {
+    parse-command-line "$@"
+
     git push upstream HEAD:master && rm $msgfile
     git checkout master
     git branch -d ${source}-${branch}
@@ -58,26 +79,16 @@ github-push()
 
 github-reset()
 {
+    parse-command-line "$@"
+
     git reset --hard
     git checkout master
     git branch -D ${source}-${branch}
 }
 
-[ $# = 3 ] || usage
-
-topdir=$(git rev-parse --show-toplevel)
-upstream_url=$(git remote get-url upstream)
-project=$(basename $upstream_url .git)
-source=$(<<< "$2" cut -d: -f1 --only-delimited)
-branch=$(<<< "$2" cut -d: -f2 --only-delimited)
-[ -z "$source" -o -z "$branch" ] && usage
-source_url=https://github.com/$source/$project
-preq=$3
-msgfile="$topdir/.git/PULL_REQUEST_EDITMSG"
-
 case "$1" in
     pull|commit|push|reset)
-        eval github-$1 ;;
+        eval github-$1 "$@" ;;
     *)
         usage ;;
 esac

--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -14,6 +14,8 @@ Commands:
 
 list:   List open pull requests in the upstream repository.
 
+show <pullrequest#>: Show detailed information about a pull request.
+
 pull:   Pulls forked branch into local branch of upstream/master, and
         leaves it in a non-committed state for inspection and testing.
 
@@ -38,6 +40,29 @@ github-list()
         jq -r \
            '.[] |
             @text "\(.number) (\(.head.label)): \(.title)"'
+}
+
+github-show()
+{
+    [ $# = 2 ] || usage
+
+    local org repo num
+    org=$(git remote get-url upstream | cut -d: -f2 | cut -d/ -f1)
+    repo=$(basename $(git remote get-url upstream | cut -d: -f2 | cut -d/ -f2) .git)
+    curl --silent https://api.github.com/repos/$org/$repo/pulls/$2 | \
+        jq -r \
+           '@text
+"Pull request #\(.number): \(.title)
+URL: \(.html_url)
+Label: \(.head.label)
+\(.commits) commits
+State: \(.state)
+Last update: \(.updated_at)
+Created by: \(.user.login)
+From repo: \(.head.repo.full_name)
+Branch: \(.head.ref)
+
+\(.body)"'
 }
 
 parse-command-line()
@@ -100,7 +125,7 @@ github-reset()
 }
 
 case "$1" in
-    list|pull|commit|push|reset)
+    list|show|pull|commit|push|reset)
         eval github-$1 "$@" ;;
     *)
         usage ;;

--- a/git-ghpr/bin/git-ghpr
+++ b/git-ghpr/bin/git-ghpr
@@ -12,6 +12,8 @@ repository
 
 Commands:
 
+list:   List open pull requests in the upstream repository.
+
 pull:   Pulls forked branch into local branch of upstream/master, and
         leaves it in a non-committed state for inspection and testing.
 
@@ -25,6 +27,17 @@ reset:  Resets working copy to local master and deletes the temporary
 WARNING: No github API validation of the PR is done.
 EOF
     exit 1
+}
+
+github-list()
+{
+    local org repo
+    org=$(git remote get-url upstream | cut -d: -f2 | cut -d/ -f1)
+    repo=$(basename $(git remote get-url upstream | cut -d: -f2 | cut -d/ -f2) .git)
+    curl --silent https://api.github.com/repos/$org/$repo/pulls | \
+        jq -r \
+           '.[] |
+            @text "\(.number) (\(.head.label)): \(.title)"'
 }
 
 parse-command-line()
@@ -87,7 +100,7 @@ github-reset()
 }
 
 case "$1" in
-    pull|commit|push|reset)
+    list|pull|commit|push|reset)
         eval github-$1 "$@" ;;
     *)
         usage ;;


### PR DESCRIPTION
Make `git-ghpr` take only a pull request number, and find all other information using the JSON API.

Uses the v3 JSON API instead of the v4 GraphQL API, since we only want a very small amount of public information, which we can do in v3 by constructing a URL, while v4 would require authenticating and constructing a JSON query.

Additional requirements: `curl` and `jq`. For those running CentOS, `jq` is available in EPEL.

New subcommands: `list` (list open pull requests), `show <pr#>` (show information about one pull request).

I've tested as far as I can locally, but I haven't bothered setting up a test repo to send pull requests to myself and test the entire workflow. Consider using this PR as an end-to-end test.

This code continues the fine tradition of not doing any error handling whatsoever, but everything I've thrown at it so far has been obviously fixable using standard Git commands.

Closes #9.