### PR TITLE
Minor README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Workflow tools #
+
+Various small tools for supporting Git and GitHub workflows.
+
+For information on which tools are available and how to install them,
+see the `README.md` files in each tool's directory.

--- a/git-ghpr/README
+++ b/git-ghpr/README
@@ -1,9 +1,0 @@
-# GitHub Pull Request helper #
-
-Crude helper tool for merging pull requests on github, when the
-workflow requires that all commits are gpg signed.
-
-Requires the curl and jq utilities.
-
-Copy bin/git-ghpr to somewhere in $PATH, to make the `git ghpr`
-subcommand available.

--- a/git-ghpr/README.md
+++ b/git-ghpr/README.md
@@ -1,0 +1,9 @@
+# GitHub Pull Request helper #
+
+Crude helper tool for merging pull requests on GitHub, when the
+workflow requires that all commits are GPG signed.
+
+Requires the `curl` and `jq` utilities.
+
+Copy `bin/git-ghpr` to somewhere in $PATH, to make the `git ghpr`
+subcommand available.

--- a/git-hooks/README.md
+++ b/git-hooks/README.md
@@ -1,4 +1,4 @@
 # enforce-workflow #
 
-A server-side pre-receive git hook for checking the GPG signature and
+A server-side pre-receive Git hook for checking the GPG signature and
 other small workflow things of a pushed commit.

--- a/git-hooks/enforce-workflow/README.md
+++ b/git-hooks/enforce-workflow/README.md
@@ -11,9 +11,10 @@ The hook is available in two forms, `pre-push` for local checks on the
 client, to check that you aren't pushing something obviously wrong,
 and `pre-receive` for server-side enforcement.
 
-The `pre-push` hook does not validate signers, since that list is not
-necessarily available on the client side. Signatures are still checked
-for validity by GnuPG.
+In the `pre-push` hook, validation of signers is optional, since that
+list is not necessarily available on the client side and it can't do
+any enforcement anyway. Signatures are still checked for validity by
+GnuPG.
 
 
 ## Installation
@@ -22,11 +23,13 @@ Place `workflow_enforcer.rb` and the correct wrapper (`pre-push` on
 clients, `pre-receive` on servers) in your Git hooks directory,
 `.git/hooks/`.
 
-For the server-side `pre-receive` hook, also place the
-`collaborators.yaml` file in your `.git/` directory. This file should
-contain a YAML hash from usernames to GnuPG key fingerprints
-(40-character hex strings). Generate fingerprints by running `gpg
---fingerprint --with-colons <e-mail> | grep ^fpr | cut -d: -f 10`.
+For signer validation (required for `pre-receive`, optional for
+`pre-push`), also place the `collaborators.yaml` file in your `.git/`
+directory. This file should contain a YAML hash from usernames to
+GnuPG key fingerprints (40-character hex strings). Generate
+fingerprints by running `gpg --fingerprint --with-colons <e-mail> |
+grep ^fpr | cut -d: -f 10`. Only keys appearing in this list will be
+allowed to sign commits.
 
 
 ## Configuration


### PR DESCRIPTION
* Use Markdown all the way, not just haphazardly.
* Add a top-level README, to make GitHub happy.
* Fix documentation of signer validation in the `pre-push` hook to match reality.